### PR TITLE
Start BigQuery support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,9 @@ jobs:
           - ubuntu-latest
           # - windows-latest
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
@@ -78,6 +81,36 @@ jobs:
           ACTIVERECORD_ADBC_ADAPTER_BACKEND: duckdb
         run: |
           bundle exec rake
+      # BigQuery tests run on a single Ruby version to avoid conflicts.
+      # All matrix jobs share the same dataset, so parallel runs would
+      # interfere with each other (e.g. concurrent CREATE/DROP TABLE).
+      - name: Authenticate to Google Cloud
+        if: matrix.ruby-version == '3.4'
+        id: gcp-auth
+        uses: google-github-actions/auth@v3
+        continue-on-error: true
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      - name: "Prepare test environment: BigQuery"
+        if: matrix.ruby-version == '3.4' && steps.gcp-auth.outcome == 'success'
+        uses: columnar-tech/setup-dbc@v1
+        with:
+          drivers: bigquery
+      - name: "Set LD_LIBRARY_PATH for BigQuery driver"
+        if: matrix.ruby-version == '3.4' && steps.gcp-auth.outcome == 'success'
+        run: |
+          driver_dir=$(dirname "$(find ~/.config/adbc/drivers -name 'libadbc_driver_bigquery.so' -print -quit)")
+          echo "LD_LIBRARY_PATH=${driver_dir}:${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
+      - name: "Test: BigQuery"
+        if: matrix.ruby-version == '3.4' && steps.gcp-auth.outcome == 'success'
+        continue-on-error: true
+        env:
+          ACTIVERECORD_ADBC_ADAPTER_BACKEND: bigquery
+          GOOGLE_CLOUD_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+          BIGQUERY_DATASET: adbc_test
+        run: |
+          bundle exec ruby test/run.rb --testcase=TestModel
       - name: Install benchmark dependencies
         run: |
           # We can use this with ubuntu-26.04.

--- a/lib/activerecord_adbc_adapter/adapter.rb
+++ b/lib/activerecord_adbc_adapter/adapter.rb
@@ -141,9 +141,14 @@ module ActiveRecordADBCAdapter
     #
     # The MIT license.
     def build_insert_sql(insert)
-      sql = +"INSERT #{insert.into} #{insert.values_list}"
+      into = insert.into
+      if backend == "bigquery"
+        into = into.sub(insert.model.quoted_table_name,
+                        quote_table_name(insert.model.table_name))
+      end
+      sql = +"INSERT #{into} #{insert.values_list}"
 
-      if insert.skip_duplicates?
+      if insert.skip_duplicates? && backend != "bigquery"
         sql << " ON CONFLICT #{insert.conflict_target} DO NOTHING"
       elsif insert.update_duplicates?
         sql << " ON CONFLICT #{insert.conflict_target} DO UPDATE SET "
@@ -198,6 +203,10 @@ module ActiveRecordADBCAdapter
     end
 
     def detect_features_postgresql
+      @features[:supports_insert_on_duplicate_skip] = true
+    end
+
+    def detect_features_bigquery
       @features[:supports_insert_on_duplicate_skip] = true
     end
 

--- a/lib/activerecord_adbc_adapter/quoting.rb
+++ b/lib/activerecord_adbc_adapter/quoting.rb
@@ -10,6 +10,22 @@ module ActiveRecordADBCAdapter
       end
     end
 
+    def quote_column_name(column_name)
+      if backend == "bigquery"
+        "`#{column_name.to_s.gsub('`', '\\`')}`"
+      else
+        self.class.quote_column_name(column_name)
+      end
+    end
+
+    def quote_table_name(table_name)
+      if backend == "bigquery"
+        "`#{table_name.to_s.gsub('`', '\\`')}`"
+      else
+        self.class.quote_table_name(table_name)
+      end
+    end
+
     def quoted_date(value)
       value
     end

--- a/lib/activerecord_adbc_adapter/schema_statements.rb
+++ b/lib/activerecord_adbc_adapter/schema_statements.rb
@@ -1,6 +1,9 @@
 module ActiveRecordADBCAdapter
   module SchemaStatements
     NATIVE_DATABASE_TYPES = {
+      "bigquery" => {
+        primary_key: "INT64 PRIMARY KEY NOT ENFORCED",
+      },
       "duckdb" => {
         primary_key: "bigint PRIMARY KEY",
       },

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,10 @@ module Helper
       ENV["ACTIVERECORD_ADBC_ADAPTER_BACKEND"]
     end
 
+    def bigquery?
+      backend == "bigquery"
+    end
+
     def duckdb?
       backend == "duckdb"
     end
@@ -32,6 +36,7 @@ module Helper
     end
 
     def sqlite?
+      return false if bigquery?
       return false if duckdb?
       return false if postgresql?
       true
@@ -41,6 +46,14 @@ module Helper
       suffix = nil
       database = "ar_adbc_test"
       case backend
+      when "bigquery"
+        options = {
+          driver: "adbc_driver_bigquery",
+          "adbc.bigquery.sql.project_id":
+            ENV.fetch("GOOGLE_CLOUD_PROJECT"),
+          "adbc.bigquery.sql.dataset_id":
+            ENV.fetch("BIGQUERY_DATASET", "adbc_test"),
+        }
       when "duckdb"
         suffix = ".duckdb"
         path_key = :path
@@ -83,6 +96,13 @@ module Helper
           options[path_key] = @db_path
           setup.call
         end
+      elsif bigquery?
+        # Ideally we'd create/drop a temporary dataset per test run
+        # (like PostgreSQL creates/drops a database), but the ADBC
+        # BigQuery driver requires dataset_id for all SQL execution
+        # — even CREATE SCHEMA fails without it. So we reuse an
+        # existing dataset and drop tables in teardown instead.
+        setup.call
       else
         adapter_class = ActiveRecord::ConnectionAdapters.resolve(ar_adapter_name)
         adapter = adapter_class.new(ar_adapter_options)

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -10,6 +10,12 @@ class TestModel < Test::Unit::TestCase
                     ])
   end
 
+  teardown do
+    if bigquery?
+      ActiveRecord::Base.connection.drop_table("users", if_exists: true)
+    end
+  end
+
   def test_first
     assert_equal(User.new(id: 1), User.select(:id).first)
   end
@@ -28,6 +34,10 @@ class TestModel < Test::Unit::TestCase
   end
 
   sub_test_case(".ingest") do
+    setup do
+      omit("BigQuery doesn't support ADBC ingest") if bigquery?
+    end
+
     def id_array
       Arrow::Int64Array.new([4, 5, 6])
     end

--- a/test/test_type.rb
+++ b/test/test_type.rb
@@ -1,6 +1,18 @@
 class TestType < Test::Unit::TestCase
   include Helper::Sandbox
 
+  setup do
+    if bigquery?
+      omit("BigQuery type tests are not yet implemented")
+    end
+  end
+
+  teardown do
+    if bigquery?
+      ActiveRecord::Base.connection.drop_table("users", if_exists: true)
+    end
+  end
+
   def test_boolean_active_record
     ActiveRecord::Base.connection.create_table("users") do |table|
       table.boolean :boolean


### PR DESCRIPTION
This is the first step toward BigQuery backend support.
More features will be added incrementally.

CI has passed on my fork here.
- https://github.com/otegami/activerecord-adbc-adapter/actions/runs/24180042113/job/70570412506#step:14:1

## Done
- Basic connectivity and query execution (TestModel passes)
- Backtick quoting for identifiers
- insert_all without ON CONFLICT (BigQuery does not support it)
  - https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax#merge_statement 

## Not done
- Type support (boolean, string, date, etc.)
- Ingest (ADBC BigQuery driver does not implement ingest API)
  - https://github.com/apache/arrow-adbc/issues/2172 

## FYI
- Tests assume GCP project and dataset already exist (ADBC BigQuery driver requires dataset_id for all SQL execution)
  - I will write the documentation about how to set up GCP's access keys.