### PR TITLE
Fix: scope to_arrow / each_record_batch to ADBC connections

### DIFF
--- a/lib/activerecord_adbc_adapter/relation_arrowable.rb
+++ b/lib/activerecord_adbc_adapter/relation_arrowable.rb
@@ -1,18 +1,40 @@
 module ActiveRecordADBCAdapter
   module RelationArrowable
-    def to_arrow
-      result = exec_main_query
-      result.attach_model(model)
-      result.to_arrow
+    def to_arrow(...)
+      if adbc_connection?
+        result = exec_main_query
+        result.attach_model(model)
+        result.to_arrow
+      elsif defined?(super)
+        super(...)
+      else
+        raise NoMethodError,
+              "#{model}#to_arrow is only available on ADBC-backed connections " \
+              "(install red-arrow-activerecord for non-ADBC support)"
+      end
     end
 
     def each_record_batch(&block)
-      result = exec_main_query
-      result.attach_model(model)
-      result.each_record_batch(&block)
+      if adbc_connection?
+        result = exec_main_query
+        result.attach_model(model)
+        result.each_record_batch(&block)
+      elsif defined?(super)
+        super(&block)
+      else
+        raise NoMethodError,
+              "#{model}#each_record_batch is only available on ADBC-backed connections"
+      end
+    end
+
+    private
+    def adbc_connection?
+      model.with_connection do |connection|
+        connection.is_a?(ActiveRecordADBCAdapter::Adapter)
+      end
     end
   end
 
-  ActiveRecord::Relation.include(RelationArrowable)
+  ActiveRecord::Relation.prepend(RelationArrowable)
   ActiveRecord::Querying.delegate(:to_arrow, :each_record_batch, to: :all)
 end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -68,6 +68,13 @@ class TestModel < Test::Unit::TestCase
       assert_equal(Arrow::Table.new(id: Arrow::Int64Array.new([1, 2, 3])),
                    User.all.order(:id).to_arrow)
     end
+
+    def test_non_adbc_connection_raises
+      relation = User.all
+      relation.singleton_class.define_method(:adbc_connection?) { false }
+      error = assert_raise(NoMethodError) { relation.to_arrow }
+      assert_match(/only available on ADBC/, error.message)
+    end
   end
 
   sub_test_case("#each_record_batch") do


### PR DESCRIPTION
## Summary

  `to_arrow` and `each_record_batch` were leaking onto every
  `ActiveRecord::Relation`. Any model not backed by ADBC crashed with
  `NoMethodError: undefined method 'attach_model' for an instance of
  ActiveRecord::Result`. That made this gem unsafe to drop into a Rails

  Both methods now check the model's connection. ADBC keeps the fast
  path. Anything else calls `super`, so `red-arrow-activerecord` can
  take over if it's loaded; otherwise you get a `NoMethodError` that
  actually names the problem instead of an `attach_model` traceback.

  The module is `prepend`ed instead of `include`d, so the guard wins
  method lookup whichever order the gems get required in.