### PR TITLE
ci: pin GR runtime to 0.73.22 to avoid grm_export crash

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,9 +85,13 @@ jobs:
           #   gr-framework-plugin-base \
           #   gr-framework-plugin-full \
           #   libgr-framework-dev
-          latest_gr_tag=$(curl https://api.github.com/repos/sciapp/gr/tags | \
-                            jq -r '.[].name' | \
-                            head -n 1)
+          #
+          # Pin GR until the grm_export fix (sciapp/gr#204, #205) ships in
+          # a release; then drop the pin and restore the latest-tag lookup.
+          # latest_gr_tag=$(curl https://api.github.com/repos/sciapp/gr/tags | \
+          #                   jq -r '.[].name' | \
+          #                   head -n 1)
+          latest_gr_tag=v0.73.22
           latest_gr_version=${latest_gr_tag#v}
           wget \
             --output-document gr.tar.gz \


### PR DESCRIPTION
The Benchmark step downloads the latest GR release, but GR 0.73.23 and later segfault in grm_export() when called with no active figure -- the grm_merge -> grm_export flow benchmark/load-dump.rb uses (regression from sciapp/gr@b7520a3c). Pin to 0.73.22, the last release before it.

A fix is proposed upstream (sciapp/gr#204); drop the pin and restore the latest-tag lookup once a GR release with it ships.
- https://github.com/sciapp/gr/issues/204