### PR TITLE
ci: drop EOL Ruby 3.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.2"
           - "3.3"
           - "3.4"
         runs-on:


### PR DESCRIPTION
Ruby 3.2 reached EOL on 2026-04-01
- ref: https://www.ruby-lang.org/en/downloads/branches/